### PR TITLE
Update video_player dependency reference

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     git: 
       url: https://github.com/Ahlisen/packages
       path: packages/video_player/video_player
-      #ref: 66fd7b0fae113d2666369a91d729b7f764ab5278
+      ref: 47bd256ed66ce42900513ec9ff68aba64ab60d88
   video_thumbnail: ^0.5.3
 
 dev_dependencies:


### PR DESCRIPTION
Bra att ha ref för att se till så att det man har lokalt uppdateras till det senaste korrekt. Annars kan det bli strul mellan denna och video_player i app-yaml:en